### PR TITLE
tunnel/winipcfg: set SysProcAttr.HideWindow when running netsh.sh

### DIFF
--- a/tunnel/winipcfg/netsh.go
+++ b/tunnel/winipcfg/netsh.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
@@ -25,6 +26,8 @@ func runNetsh(cmds []string) error {
 		return err
 	}
 	cmd := exec.Command(filepath.Join(system32, "netsh.exe")) // I wish we could append (, "-f", "CONIN$") but Go sets up the process context wrong.
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("runNetsh stdin pipe - %v", err)


### PR DESCRIPTION
Prevents cmd.exe window flashes when running binaries in elevated
interactive contexts for debugging.

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>