### PR TITLE
l18n: isolate GOOS=windows code

### DIFF
--- a/l18n/l18n.go
+++ b/l18n/l18n.go
@@ -8,7 +8,6 @@ package l18n
 import (
 	"sync"
 
-	"golang.org/x/sys/windows"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
@@ -35,7 +34,7 @@ func prn() *message.Printer {
 func lang() (tag language.Tag) {
 	tag = language.English
 	confidence := language.No
-	languages, err := windows.GetUserPreferredUILanguages(windows.MUI_LANGUAGE_NAME)
+	languages, err := getUserLanguages()
 	if err != nil {
 		return
 	}

--- a/l18n/l18n_other.go
+++ b/l18n/l18n_other.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 WireGuard LLC. All Rights Reserved.
+ */
+
+package l18n
+
+func getUserLanguages() ([]string, error) {
+	return []string{}, nil
+}

--- a/l18n/l18n_windows.go
+++ b/l18n/l18n_windows.go
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 WireGuard LLC. All Rights Reserved.
+ */
+
+package l18n
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func getUserLanguages() ([]string, error) {
+	return windows.GetUserPreferredUILanguages(windows.MUI_LANGUAGE_NAME)
+}


### PR DESCRIPTION
Found when looking at `golang.zx2c4.com/wireguard/windows/conf`, that it
fails on linux, do to this bit.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>