### PR TITLE
tunnel/winipcfg, embeddable-dll-service: fix Go 1.15 checkptr violations

### DIFF
--- a/embeddable-dll-service/main.go
+++ b/embeddable-dll-service/main.go
@@ -22,7 +22,7 @@ import (
 
 //export WireGuardTunnelService
 func WireGuardTunnelService(confFile16 *uint16) bool {
-	confFile := windows.UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(confFile16))[:])
+	confFile := windows.UTF16PtrToString(confFile16)
 	conf.PresetRootDirectory(filepath.Dir(confFile))
 	tunnel.UseFixedGUIDInsteadOfDeterministic = true
 	err := tunnel.Run(confFile)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lxn/win v0.0.0-20191128105842-2da648fda5b4
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
+	golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a
 	golang.org/x/text v0.3.3
 	golang.zx2c4.com/wireguard v0.0.20200321-0.20200715051853-507f148e1c42
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a h1:e3IU37lwO4aq3uoRKINC7JikojFmE5gO7xhfxs8VC34=
+golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=

--- a/tunnel/winipcfg/winipcfg_test.go
+++ b/tunnel/winipcfg/winipcfg_test.go
@@ -107,7 +107,7 @@ func TestAdaptersAddresses(t *testing.T) {
 			i.PhysicalAddress()
 			i.DHCPv6ClientDUID()
 			for dnsSuffix := i.FirstDNSSuffix; dnsSuffix != nil; dnsSuffix = dnsSuffix.Next {
-				dnsSuffix.String()
+				_ = dnsSuffix.String()
 			}
 		}
 	}

--- a/version/wintrust/certificate_windows.go
+++ b/version/wintrust/certificate_windows.go
@@ -48,7 +48,9 @@ func ExtractCertificates(path string) ([]x509.Certificate, error) {
 			break
 		}
 		buf := make([]byte, cert.Length)
-		copy(buf, (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:])
+		for i := range buf {
+			buf[i] = *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(cert.EncodedCert)) + uintptr(i)))
+		}
 		if c, err := x509.ParseCertificate(buf); err == nil {
 			certs = append(certs, *c)
 		} else {


### PR DESCRIPTION
Avoids "converted pointer straddles allocation" failures at runtime
when building binaries in race mode with Go 1.15.

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>