### PR TITLE
Override configs on migration

### DIFF
--- a/conf/migration_windows.go
+++ b/conf/migration_windows.go
@@ -87,7 +87,7 @@ func migrateUnencryptedConfigs(sharingBase int, migrated MigrationCallback) {
 		if err != nil {
 			goto error
 		}
-		err = config.Save(false)
+		err = config.Save(true)
 		if err != nil {
 			goto error
 		}


### PR DESCRIPTION
Enable overriding existed *.conf.dpapi.

In current release, on add file to C:\Program Files\WireGuard\Data\Configurations with name that exist, app will go to loop, because can't create already existed file.
Log:
```
2021-10-31 04:33:00.174068: [MGR] Unable to ingest and encrypt `C:\Program Files\WireGuard\Data\Configurations\srv1-over-oracle1.conf`: Cannot create a file when that file already exists.
2021-10-31 04:33:00.175679: [MGR] Unable to ingest and encrypt `C:\Program Files\WireGuard\Data\Configurations\srv1-over-oracle1.conf`: Cannot create a file when that file already exists.
2021-10-31 04:33:00.177246: [MGR] Unable to ingest and encrypt `C:\Program Files\WireGuard\Data\Configurations\srv1-over-oracle1.conf`: Cannot create a file when that file already exists.
....
```

If my solution is not suitable, I hope that someone will fix the problem differently.