### PR TITLE
Fixing Cidr struct offset

### DIFF
--- a/embeddable-dll-service/csharp/TunnelDll/Driver.cs
+++ b/embeddable-dll-service/csharp/TunnelDll/Driver.cs
@@ -226,7 +226,7 @@ namespace Tunnel
                 public Win32.IN6_ADDR V6;
                 [FieldOffset(16)]
                 public Win32.ADDRESS_FAMILY AddressFamily;
-                [FieldOffset(20)]
+                [FieldOffset(18)]
                 public byte Cidr;
             }
         }


### PR DESCRIPTION
Win32.ADDRESS_FAMILY is 2 bytes, so Cidr offset should be 18